### PR TITLE
Fix dedicated server crash

### DIFF
--- a/1.20.1/Forge/Macaw's Fences - BYG/src/main/java/fr/samlegamer/mcwfencesbyg/McwFencesBYG.java
+++ b/1.20.1/Forge/Macaw's Fences - BYG/src/main/java/fr/samlegamer/mcwfencesbyg/McwFencesBYG.java
@@ -25,8 +25,15 @@ public class McwFencesBYG
     public McwFencesBYG()
     {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::AddTab);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::colorsBlock);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::colorsItem);
+
+	// check if this is on client or server
+	// NEVER use @onlyin(Dist.CLIENT) tags in mod code
+	Level level = pContext.getLevel();
+	if (level.isClientSide){
+        	FMLJavaModLoadingContext.get().getModEventBus().addListener(this::colorsBlock);
+        	FMLJavaModLoadingContext.get().getModEventBus().addListener(this::colorsItem);
+	}
+	    
         LOGGER.info("Macaw's Fences - Oh The Biomes We've Gone : Loading ...");
 		IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
 		MFBYGBlocksRegistry.ITEMS_REGISTRY.register(bus);
@@ -36,7 +43,6 @@ public class McwFencesBYG
     }
     
     
-    @OnlyIn(Dist.CLIENT)
     private void colorsBlock(RegisterColorHandlersEvent.Block e)
     {
     	/*
@@ -50,7 +56,6 @@ public class McwFencesBYG
     }
     
 
-    @OnlyIn(Dist.CLIENT)
     private void colorsItem(RegisterColorHandlersEvent.Item e)
     {
     	/*


### PR DESCRIPTION
remove @onlyin(Dist.CLIENT) tags as they should never be used in mod code. 
Instead use a check of Level.isClientSide to check if code should be run.
Should fix issue #15, but i have no idea what im doing, and cant build it to test.
If this does work and I didnt just break things worse, implement this change ANYWHERE you are using those tags. Prevent issues like that from happening where it cant find a function due to not being loaded because of one